### PR TITLE
fix: AgentCore/Lambdaデプロイ失敗を解消

### DIFF
--- a/.github/workflows/deploy-agentcore.yml
+++ b/.github/workflows/deploy-agentcore.yml
@@ -35,7 +35,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install AgentCore CLI
-        run: pip install bedrock-agentcore-starter-toolkit
+        run: |
+          pip install uv bedrock-agentcore-starter-toolkit
+          uv --version
+          agentcore --version
 
       - name: Deploy AgentCore Runtime
         working-directory: agentcore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,14 +37,28 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest ./lambda
+          docker buildx build \
+            --platform linux/amd64 \
+            --provenance=false \
+            --sbom=false \
+            --load \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            ./lambda
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
       - name: Update Lambda function
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
+          IMAGE_DIGEST=$(aws ecr describe-images \
+            --repository-name $ECR_REPOSITORY \
+            --image-ids imageTag=$IMAGE_TAG \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+
           aws lambda update-function-code \
             --function-name line-shop-bot-dev \
-            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:latest
+            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST

--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -47,7 +47,13 @@ jobs:
           ECR_REPOSITORY: line-shop-bot-${{ inputs.environment }}
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ./lambda
+          docker buildx build \
+            --platform linux/amd64 \
+            --provenance=false \
+            --sbom=false \
+            --load \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            ./lambda
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: Update Lambda function
@@ -56,9 +62,15 @@ jobs:
           ECR_REPOSITORY: line-shop-bot-${{ inputs.environment }}
           IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
+          IMAGE_DIGEST=$(aws ecr describe-images \
+            --repository-name $ECR_REPOSITORY \
+            --image-ids imageTag=$IMAGE_TAG \
+            --query 'imageDetails[0].imageDigest' \
+            --output text)
+
           aws lambda update-function-code \
             --function-name line-shop-bot-${{ inputs.environment }} \
-            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            --image-uri $ECR_REGISTRY/$ECR_REPOSITORY@$IMAGE_DIGEST
 
       - name: Wait for Lambda update
         run: |


### PR DESCRIPTION
## 概要
- Issue #10 の AgentCore Runtime デプロイ失敗を修正
- 直近で発生していた Lambda デプロイ失敗（image manifest not supported）も修正

## 変更内容
- `.github/workflows/deploy-agentcore.yml`
  - `uv` をインストールして `agentcore deploy` 実行前に利用可能化
- `.github/workflows/deploy.yml`
  - `docker buildx build --platform linux/amd64 --provenance=false --sbom=false --load` に変更
  - Lambda 更新時に `:latest` ではなく ECR の `imageDigest` を使うよう変更
- `.github/workflows/manual-deploy.yml`
  - 同様に buildx + digest 指定へ変更

## 原因と対策
- AgentCore: `direct_code_deploy` で `uv` が必須だが、CIで未導入だった
- Lambda: GitHub Actionsビルド成果物が Lambda 非対応メディアタイプになりうるため、単一マニフェスト化して digest 指定で更新

## 関連
- Closes #10
