### PR TITLE
feat: add repository-specific development skills

### DIFF
--- a/.kiro/skills/line-bot-agentcore-deploy/SKILL.md
+++ b/.kiro/skills/line-bot-agentcore-deploy/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: line-bot-agentcore-deploy
+description: Deploy and troubleshoot the AgentCore Runtime for this repository. Use when working on `agentcore/`, fixing `deploy-agentcore.yml`, diagnosing CI failures in AgentCore deployment, or validating `.bedrock_agentcore.yaml` and direct_code_deploy prerequisites.
+---
+
+# LINE Bot AgentCore Deploy
+
+## Overview
+
+Use this skill to deploy `agentcore/` safely in local and CI contexts.
+Focus on preventing known failures in GitHub Actions, especially missing `uv` for `direct_code_deploy`.
+
+## Workflow
+
+1. Validate runtime config and credentials.
+- Confirm AWS auth: `aws sts get-caller-identity`
+- Confirm config file exists: `agentcore/.bedrock_agentcore.yaml`
+- Confirm entrypoint exists: `agentcore/src/main.py`
+
+2. Validate CLI prerequisites.
+- Ensure `agentcore` CLI is installed.
+- Ensure `uv` is installed when `deployment_type: direct_code_deploy`.
+
+3. Deploy AgentCore runtime.
+- Local deploy:
+  - `cd agentcore`
+  - `agentcore deploy --auto-update-on-conflict`
+
+4. Verify deployment outputs.
+- Check runtime ARN and deployment logs in CLI output.
+- Confirm expected runtime values in `.bedrock_agentcore.yaml`.
+
+## CI Guidance
+
+For `.github/workflows/deploy-agentcore.yml`:
+- Install both `bedrock-agentcore-starter-toolkit` and `uv` before deploy.
+- Keep `working-directory: agentcore` for deploy step.
+- Optionally print versions (`uv --version`, `agentcore --version`) for faster triage.
+
+## Known Failure Pattern
+
+- Error:
+  - `uv is required for direct_code_deploy deployment but was not found`
+- Fix:
+  - Add `pip install uv bedrock-agentcore-starter-toolkit` in workflow setup.
+
+## References
+
+- AgentCore CI runbook: `references/agentcore-ci-runbook.md`

--- a/.kiro/skills/line-bot-agentcore-deploy/agents/openai.yaml
+++ b/.kiro/skills/line-bot-agentcore-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LINE Bot AgentCore Deploy"
+  short_description: "Deploy AgentCore runtime and fix CI prerequisites"
+  default_prompt: "Use $line-bot-agentcore-deploy to deploy AgentCore runtime and troubleshoot CI failures."

--- a/.kiro/skills/line-bot-agentcore-deploy/references/agentcore-ci-runbook.md
+++ b/.kiro/skills/line-bot-agentcore-deploy/references/agentcore-ci-runbook.md
@@ -1,0 +1,45 @@
+# AgentCore CI Runbook
+
+## Target files
+
+- `.github/workflows/deploy-agentcore.yml`
+- `agentcore/.bedrock_agentcore.yaml`
+- `agentcore/src/main.py`
+
+## Baseline checks
+
+1. Workflow auth
+- OIDC role must have permissions for AgentCore deploy APIs and related resources.
+
+2. Tooling
+- Python setup done (`actions/setup-python`)
+- `pip install uv bedrock-agentcore-starter-toolkit`
+
+3. Working directory
+- Deploy command runs with `working-directory: agentcore`
+
+4. Config compatibility
+- `.bedrock_agentcore.yaml` has valid `entrypoint`, `deployment_type`, and AWS region/account.
+
+## Common errors and fixes
+
+### `uv is required for direct_code_deploy deployment but was not found`
+
+Cause:
+- CLI mode requires `uv` in runner environment.
+
+Fix:
+- Install `uv` in workflow before deploy.
+
+### Runtime deploy works locally but fails in CI
+
+Likely causes:
+- Missing dependency (`uv` / wrong CLI package)
+- Wrong IAM role assumptions in workflow
+- Mismatch between workflow cwd and config path
+
+Fix order:
+1. Verify install step and versions.
+2. Verify `working-directory` and paths.
+3. Verify IAM role permissions.
+4. Re-run with failed-step logs.

--- a/.kiro/skills/line-bot-ci-triage/SKILL.md
+++ b/.kiro/skills/line-bot-ci-triage/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: line-bot-ci-triage
+description: Triage GitHub Actions failures for this repository quickly and consistently. Use when CI/CD runs fail, when asked to identify failing workflow steps, collect failed logs, correlate failures to known patterns, and propose minimal fixes for workflows in `.github/workflows/`.
+---
+
+# LINE Bot CI Triage
+
+## Overview
+
+Use this skill to diagnose GitHub Actions failures with minimal back-and-forth.
+Start from failed runs, extract failed-step logs, map to known failure patterns, then propose targeted fixes.
+
+## Workflow
+
+1. List recent failed runs.
+- Run: `./.kiro/skills/line-bot-ci-triage/scripts/gh_failed_runs.sh --limit 20`
+- Filter workflow if needed:
+  - `./.kiro/skills/line-bot-ci-triage/scripts/gh_failed_runs.sh --workflow "Deploy to ECR" --limit 20`
+
+2. Inspect a specific failed run.
+- Run: `./.kiro/skills/line-bot-ci-triage/scripts/gh_failed_runs.sh --run-id <id>`
+
+3. Map to known patterns.
+- Read: `references/known-failures.md`
+- Confirm exact failing command and error message.
+
+4. Propose minimal fix and verify scope.
+- Patch only relevant workflow files.
+- Keep deploy behavior unchanged unless required by the fix.
+
+## Guardrails
+
+- Prefer `gh run view <id> --log-failed` over full logs first.
+- Preserve existing branch/path triggers unless explicitly asked to change.
+- Treat missing credentials/config separately from code regressions.
+
+## References
+
+- Known CI failures: `references/known-failures.md`
+- Triage script: `scripts/gh_failed_runs.sh`

--- a/.kiro/skills/line-bot-ci-triage/agents/openai.yaml
+++ b/.kiro/skills/line-bot-ci-triage/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LINE Bot CI Triage"
+  short_description: "Investigate GitHub Actions failures with fast logs"
+  default_prompt: "Use $line-bot-ci-triage to analyze failed GitHub Actions runs and suggest fixes."

--- a/.kiro/skills/line-bot-ci-triage/references/known-failures.md
+++ b/.kiro/skills/line-bot-ci-triage/references/known-failures.md
@@ -1,0 +1,38 @@
+# Known CI Failures
+
+## Deploy AgentCore Runtime
+
+Error:
+- `uv is required for direct_code_deploy deployment but was not found`
+
+Root cause:
+- `direct_code_deploy` requires `uv`, but workflow installed only AgentCore toolkit.
+
+Fix:
+- Install `uv` alongside toolkit in workflow.
+
+## Deploy to ECR -> Update Lambda function
+
+Error:
+- `The image manifest, config or layer media type ... is not supported`
+
+Root cause:
+- Image pushed in a format Lambda cannot consume (e.g., index/attestation artifacts).
+
+Fix:
+1. Build single-platform image with:
+   - `docker buildx build --platform linux/amd64 --provenance=false --sbom=false --load`
+2. Push image to ECR.
+3. Resolve digest and update Lambda with `repo@sha256:...`.
+
+## GitHub CLI GraphQL noise on issue/pr view/edit
+
+Error:
+- `Projects (classic) is being deprecated ...`
+
+Impact:
+- Some `gh issue view` or `gh pr edit` commands may fail even when target exists.
+
+Workaround:
+- Use `--json` variants for issue view when possible.
+- Use `gh api repos/<owner>/<repo>/pulls/<number> -X PATCH` for PR body updates.

--- a/.kiro/skills/line-bot-ci-triage/scripts/gh_failed_runs.sh
+++ b/.kiro/skills/line-bot-ci-triage/scripts/gh_failed_runs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LIMIT=20
+WORKFLOW=""
+RUN_ID=""
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --limit <n>          Number of runs to inspect when listing (default: 20)
+  --workflow <name>    Restrict listing to a workflow name
+  --run-id <id>        Show failed logs for a specific run ID
+  -h, --help           Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --limit)
+      LIMIT="$2"
+      shift 2
+      ;;
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$RUN_ID" ]]; then
+  echo "[INFO] Run summary for $RUN_ID"
+  gh run view "$RUN_ID"
+  echo
+  echo "[INFO] Failed-step logs for $RUN_ID"
+  gh run view "$RUN_ID" --log-failed
+  exit 0
+fi
+
+ARGS=(run list --limit "$LIMIT" --json databaseId,workflowName,headBranch,status,conclusion,createdAt,url)
+if [[ -n "$WORKFLOW" ]]; then
+  ARGS+=(--workflow "$WORKFLOW")
+fi
+
+echo "run_id workflow branch status conclusion created_at url"
+gh "${ARGS[@]}" --jq '.[] | select((.conclusion == "failure") or (.status != "completed")) | "\(.databaseId) \(.workflowName|gsub(" ";"_")) \(.headBranch) \(.status) \(.conclusion // "-") \(.createdAt) \(.url)"'

--- a/.kiro/skills/line-bot-lambda-deploy/SKILL.md
+++ b/.kiro/skills/line-bot-lambda-deploy/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: line-bot-lambda-deploy
+description: Build, push, and deploy the LINE Bot Lambda container image in this repository. Use when asked to deploy Lambda, push images to ECR, verify deployed image digests, or fix Lambda update failures such as unsupported image manifest/media type errors.
+---
+
+# LINE Bot Lambda Deploy
+
+## Overview
+
+Use this skill for deterministic Lambda container deployment in this repo (`line-shop-bot`).
+Prefer the bundled script to avoid manifest-format mistakes that break Lambda updates.
+
+## Workflow
+
+1. Validate prerequisites.
+- Confirm AWS auth: `aws sts get-caller-identity`
+- Confirm Docker daemon is running: `docker info`
+- Confirm Terraform outputs are available: `terraform -chdir=terraform output`
+
+2. Deploy with the script.
+- Run: `./.kiro/skills/line-bot-lambda-deploy/scripts/deploy_lambda_dev.sh --tag <tag>`
+- If no tag is provided, `latest` is used.
+
+3. Verify result.
+- Check Lambda status and resolved digest from script output.
+- Optional manual check:
+`aws lambda get-function --region ap-northeast-1 --function-name line-shop-bot-dev --query '{State:Configuration.State,LastUpdateStatus:Configuration.LastUpdateStatus,ResolvedImageUri:Code.ResolvedImageUri}' --output json`
+
+## Guardrails
+
+- Build image as a single-platform `linux/amd64` image with `--provenance=false --sbom=false --load`.
+- Update Lambda with digest (`repo@sha256:...`), not only mutable tags.
+- Do not assume `latest` has a Lambda-compatible manifest without verification.
+
+## Troubleshooting
+
+- If Lambda update fails with `image manifest ... not supported`:
+  rebuild and push with this skill's script, then redeploy by digest.
+- If ECR push fails due to auth:
+  rerun AWS login and ECR login, then retry.
+- If Terraform outputs are missing:
+  initialize/select correct workspace or run from the repo with configured state.
+
+## References
+
+- Deployment failure patterns: `references/lambda-deploy-failures.md`
+- Deployment script: `scripts/deploy_lambda_dev.sh`

--- a/.kiro/skills/line-bot-lambda-deploy/agents/openai.yaml
+++ b/.kiro/skills/line-bot-lambda-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LINE Bot Lambda Deploy"
+  short_description: "Build, push, and deploy Lambda container safely"
+  default_prompt: "Use $line-bot-lambda-deploy to build, push, and deploy the Lambda image."

--- a/.kiro/skills/line-bot-lambda-deploy/references/lambda-deploy-failures.md
+++ b/.kiro/skills/line-bot-lambda-deploy/references/lambda-deploy-failures.md
@@ -1,0 +1,44 @@
+# Lambda Deploy Failure Patterns
+
+## 1. Unsupported image manifest/media type
+
+Symptom:
+- `InvalidParameterValueException`
+- `The image manifest, config or layer media type ... is not supported`
+
+Likely cause:
+- Multi-arch index or attestations pushed by default build settings.
+
+Fix:
+1. Build single-platform amd64 image:
+   - `docker buildx build --platform linux/amd64 --provenance=false --sbom=false --load ...`
+2. Push to ECR.
+3. Resolve digest via `aws ecr describe-images`.
+4. Update Lambda with `repo@sha256:digest`.
+
+## 2. ECR auth failure
+
+Symptom:
+- `no basic auth credentials`
+- `denied: requested access to the resource is denied`
+
+Fix:
+- `aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin <registry>`
+
+## 3. Wrong function/repo selected
+
+Symptom:
+- update succeeds but wrong environment reflects changes.
+
+Fix:
+- Read values from Terraform outputs in this repo:
+  - `terraform -chdir=terraform output -raw ecr_repository_url`
+  - `terraform -chdir=terraform output -raw lambda_function_name`
+
+## 4. Push succeeded but Lambda still old image
+
+Likely cause:
+- tag reused without digest pinning or stale CI reference.
+
+Fix:
+- Always update Lambda with digest URI.

--- a/.kiro/skills/line-bot-lambda-deploy/scripts/deploy_lambda_dev.sh
+++ b/.kiro/skills/line-bot-lambda-deploy/scripts/deploy_lambda_dev.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGION="ap-northeast-1"
+IMAGE_TAG="latest"
+LOCAL_IMAGE="line-shop-bot"
+PUSH_LATEST=0
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Options:
+  --tag <tag>         Image tag to push/deploy (default: latest)
+  --region <region>   AWS region (default: ap-northeast-1)
+  --push-latest       Also tag and push :latest
+  -h, --help          Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      IMAGE_TAG="$2"
+      shift 2
+      ;;
+    --region)
+      REGION="$2"
+      shift 2
+      ;;
+    --push-latest)
+      PUSH_LATEST=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+  echo "[ERROR] Must run inside a git repository." >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+if [[ ! -d "lambda" || ! -d "terraform" ]]; then
+  echo "[ERROR] Expected lambda/ and terraform/ in repo root: $REPO_ROOT" >&2
+  exit 1
+fi
+
+echo "[INFO] Resolving Terraform outputs..."
+ECR_URL="$(terraform -chdir=terraform output -raw ecr_repository_url)"
+LAMBDA_FN="$(terraform -chdir=terraform output -raw lambda_function_name)"
+ECR_REGISTRY="${ECR_URL%%/*}"
+ECR_REPOSITORY="${ECR_URL##*/}"
+
+IMAGE_URI_TAG="${ECR_URL}:${IMAGE_TAG}"
+
+echo "[INFO] Building image (${LOCAL_IMAGE}:${IMAGE_TAG}) for linux/amd64..."
+docker buildx build \
+  --platform linux/amd64 \
+  --provenance=false \
+  --sbom=false \
+  --load \
+  -t "${LOCAL_IMAGE}:${IMAGE_TAG}" \
+  ./lambda
+
+echo "[INFO] Logging in to ECR (${ECR_REGISTRY})..."
+aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+
+echo "[INFO] Tagging and pushing ${IMAGE_URI_TAG} ..."
+docker tag "${LOCAL_IMAGE}:${IMAGE_TAG}" "$IMAGE_URI_TAG"
+docker push "$IMAGE_URI_TAG"
+
+if [[ "$PUSH_LATEST" -eq 1 && "$IMAGE_TAG" != "latest" ]]; then
+  echo "[INFO] Also tagging and pushing ${ECR_URL}:latest ..."
+  docker tag "${LOCAL_IMAGE}:${IMAGE_TAG}" "${ECR_URL}:latest"
+  docker push "${ECR_URL}:latest"
+fi
+
+echo "[INFO] Resolving image digest for tag '${IMAGE_TAG}'..."
+IMAGE_DIGEST="$(aws ecr describe-images \
+  --region "$REGION" \
+  --repository-name "$ECR_REPOSITORY" \
+  --image-ids imageTag="$IMAGE_TAG" \
+  --query 'imageDetails[0].imageDigest' \
+  --output text)"
+
+if [[ -z "$IMAGE_DIGEST" || "$IMAGE_DIGEST" == "None" ]]; then
+  echo "[ERROR] Failed to resolve digest for ${ECR_REPOSITORY}:${IMAGE_TAG}" >&2
+  exit 1
+fi
+
+IMAGE_URI_DIGEST="${ECR_URL}@${IMAGE_DIGEST}"
+
+echo "[INFO] Updating Lambda (${LAMBDA_FN}) with ${IMAGE_URI_DIGEST} ..."
+aws lambda update-function-code \
+  --region "$REGION" \
+  --function-name "$LAMBDA_FN" \
+  --image-uri "$IMAGE_URI_DIGEST" \
+  >/tmp/line-bot-lambda-update.json
+
+aws lambda wait function-updated \
+  --region "$REGION" \
+  --function-name "$LAMBDA_FN"
+
+echo "[INFO] Deployment complete."
+aws lambda get-function \
+  --region "$REGION" \
+  --function-name "$LAMBDA_FN" \
+  --query '{FunctionName:Configuration.FunctionName,State:Configuration.State,LastUpdateStatus:Configuration.LastUpdateStatus,ResolvedImageUri:Code.ResolvedImageUri}' \
+  --output json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+## Skills
+A skill is a set of local instructions to follow that is stored in a `SKILL.md` file.
+
+### Available skills
+- line-bot-lambda-deploy: Build/push/deploy Lambda container images for this repository, including digest-based updates and manifest compatibility handling. (file: /Users/sugimori/LINE_BOT/.kiro/skills/line-bot-lambda-deploy/SKILL.md)
+- line-bot-agentcore-deploy: Deploy and troubleshoot AgentCore Runtime in local/CI environments for this repository. (file: /Users/sugimori/LINE_BOT/.kiro/skills/line-bot-agentcore-deploy/SKILL.md)
+- line-bot-ci-triage: Investigate failed GitHub Actions runs and map failures to known patterns quickly. (file: /Users/sugimori/LINE_BOT/.kiro/skills/line-bot-ci-triage/SKILL.md)
+
+### How to use skills
+- Discovery: Use the list above to choose the minimum set of relevant skills.
+- Trigger rules: Use a skill when the request explicitly names it (`$skill-name`) or clearly matches its description.
+- Progressive disclosure: Read `SKILL.md` first, then load only the referenced files needed for the task.
+- Resource usage: Prefer bundled `scripts/` for deterministic or repetitive operations.
+- Context hygiene: Do not bulk-load all references; read only what is required.


### PR DESCRIPTION
## 概要
このリポジトリの開発運用を効率化するため、プロジェクト専用の Skills を追加しました。

## 追加した Skills
- `line-bot-lambda-deploy`
  - Lambda コンテナのビルド/Push/デプロイを安全に実行
  - digest ベース更新と manifest 互換性問題への対処を標準化
- `line-bot-agentcore-deploy`
  - AgentCore Runtime のローカル/CIデプロイ手順を明文化
  - `uv` 必須など既知の失敗要因を先回りでチェック
- `line-bot-ci-triage`
  - GitHub Actions 失敗ランの収集・分析を高速化
  - 既知障害パターンへのマッピングをガイド化

## 変更ファイル
- `AGENTS.md`
- `.kiro/skills/line-bot-lambda-deploy/**`
- `.kiro/skills/line-bot-agentcore-deploy/**`
- `.kiro/skills/line-bot-ci-triage/**`

## 検証
- `quick_validate.py` で3 Skillとも `Skill is valid!`
- 追加スクリプトの `--help` 実行確認
- `gh_failed_runs.sh --limit 5` 実行確認
